### PR TITLE
Fix bug

### DIFF
--- a/std/conf.c.modified
+++ b/std/conf.c.modified
@@ -17,7 +17,7 @@ main(int argc, char *argv[])
 	printf("no symbol for ARG_MAX\n");
 #endif
 #ifdef _SC_ARG_MAX
-	pr_sysconf("ARG_MAX =", _SC_ARG_MAX);
+	pr_sysconf((char *)"ARG_MAX =", _SC_ARG_MAX);
 #else
 	printf("no symbol for _SC_ARG_MAX\n");
 #endif
@@ -30,7 +30,7 @@ main(int argc, char *argv[])
 	printf("no symbol for MAX_CANON\n");
 #endif
 #ifdef _PC_MAX_CANON
-	pr_pathconf("MAX_CANON =", argv[1], _PC_MAX_CANON);
+	pr_pathconf((char *)"MAX_CANON =", argv[1], _PC_MAX_CANON);
 #else
 	printf("no symbol for _PC_MAX_CANON\n");
 #endif


### PR DESCRIPTION
When I try to compile this code, error occurs.

print_limitations.c: In function ‘int main(int, char*_)’:
print_limitations.c:25:44: warning: deprecated conversion from string constant to ‘char_’ [-Wwrite-strings]
         pr_sysconf("ARG_MAX =", _SC_ARG_MAX);
                                            ^
print_limitations.c:36:58: warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]
         pr_pathconf("MAX_CANON =", argv[1], _PC_MAX_CANON);
                                                          ^
and my change would fix it.
